### PR TITLE
Remediate FortiGate connector vulnerabilities

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.4
     hooks:
       - id: build-docs
         language: python

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ application. Below are the explanation and usage of all those parameters.
 - **Username -** The username used for authentication.
 - **Password -** The password used for authentication.
 - **API Key -** The API Key used for authentication.
-- **Verify server certificate -** Enable or disable verify SSL certificates for HTTPS requests.
-  The default value is false.
+- **Verify server certificate -** Enable or disable verification of TLS certificates for HTTPS
+  requests. Verification is enabled by default; disable it only after explicitly accepting the
+  man-in-the-middle risk.
 - **Virtual domain (VDOM) -** It specifies the virtual domain to be used. It is an optional
   parameter. If no virtual domain is provided, it will use the one provided in the action
   parameters. And, if the virtual domain is not provided in the asset or action parameters, it

--- a/fortigate.json
+++ b/fortigate.json
@@ -28,7 +28,7 @@
             "description": "Device URL for e.g. https://myforti.contoso.com"
         },
         "verify_server_cert": {
-            "default": false,
+            "default": true,
             "description": "Verify server certificate",
             "data_type": "boolean",
             "order": 1

--- a/fortigate_connector.py
+++ b/fortigate_connector.py
@@ -883,6 +883,9 @@ class FortiGateConnector(BaseConnector):
             self.debug_print(FORTIGATE_INVALID_POLICY_DENY)
             return action_result.set_status(phantom.APP_ERROR, FORTIGATE_INVALID_POLICY_DENY), None
 
+        if policy.get("status") != "enable":
+            return action_result.set_status(phantom.APP_ERROR, "Policy is disabled and does not block traffic"), None
+
         # If policy action is deny, store policy id
         return phantom.APP_SUCCESS, policy_id
 

--- a/fortigate_connector.py
+++ b/fortigate_connector.py
@@ -83,7 +83,7 @@ class FortiGateConnector(BaseConnector):
         self._api_password = config.get(FORTIGATE_JSON_PASSWORD)
         self._api_key = config.get(FORTIGATE_JSON_API_KEY)
         self._api_vdom = config.get(FORTIGATE_JSON_VDOM, "")
-        self._verify_server_cert = config.get(FORTIGATE_JSON_VERIFY_SERVER_CERT, False)
+        self._verify_server_cert = config.get(FORTIGATE_JSON_VERIFY_SERVER_CERT, True)
         self.set_validator("ip", self._is_ip)
 
         self._device = config[FORTIGATE_JSON_URL]

--- a/fortigate_connector.py
+++ b/fortigate_connector.py
@@ -435,6 +435,10 @@ class FortiGateConnector(BaseConnector):
 
         # Please specify the status codes here
         if 200 <= status_code < 399:
+            fortios_status = resp_json.get("status")
+            if fortios_status and str(fortios_status).lower() != "success":
+                detail = resp_json.get("error") or resp_json.get("http_status") or "FortiOS reported an unsuccessful operation"
+                return RetVal(action_result.set_status(phantom.APP_ERROR, f"FortiOS API error: {detail}"), resp_json)
             return RetVal(phantom.APP_SUCCESS, resp_json)
 
         if resp_json.get("error") or resp_json.get("error_description"):
@@ -664,6 +668,12 @@ class FortiGateConnector(BaseConnector):
         if not response:
             return action_result.set_status(phantom.APP_ERROR, FORTIGATE_UNEXPECTED_SERVER_RESPONSE)
 
+        addr_status, address_blocked = self._is_address_blocked(ip_addr_obj_name, address_type, policy_id, vdom, action_result)
+        if phantom.is_fail(addr_status):
+            return action_result.get_status()
+        if not address_blocked:
+            return action_result.set_status(phantom.APP_ERROR, "FortiGate did not add the address to the deny policy")
+
         return action_result.set_status(phantom.APP_SUCCESS, FORTIGATE_IP_BLOCKED)
 
     # Unblock IP address
@@ -748,6 +758,12 @@ class FortiGateConnector(BaseConnector):
 
         if not response:
             return action_result.set_status(phantom.APP_ERROR, FORTIGATE_UNEXPECTED_SERVER_RESPONSE)
+
+        addr_status, address_blocked = self._is_address_blocked(ip_addr_obj_name, address_type, policy_id, vdom, action_result)
+        if phantom.is_fail(addr_status):
+            return action_result.get_status()
+        if address_blocked:
+            return action_result.set_status(phantom.APP_ERROR, "FortiGate did not remove the address from the deny policy")
 
         # Blocked Successfully
         return action_result.set_status(phantom.APP_SUCCESS, FORTIGATE_IP_UNBLOCKED)
@@ -915,11 +931,6 @@ class FortiGateConnector(BaseConnector):
 
         # Check if resource not available, its an failure scenario
         if json_resp.get("resource_not_available"):
-            if self.get_action_identifier() == "unblock_ip":
-                self.debug_print(FORTIGATE_REST_RESP_RESOURCE_NOT_FOUND_MESSAGE)
-                return action_result.set_status(phantom.APP_ERROR, FORTIGATE_REST_RESP_RESOURCE_NOT_FOUND_MESSAGE), address_blocked
-
-            # For block ip, if resource not available indicates that address is not blocked
             address_blocked = False
             return phantom.APP_SUCCESS, address_blocked
 

--- a/fortigate_list_policies.html
+++ b/fortigate_list_policies.html
@@ -105,7 +105,7 @@
               <tr>
                 <td>
                   <a href="javascript:;"
-                     onclick="context_menu(this, [{'contains': ['fortigate policy'], 'value': '{{ d.name }}' }], 0, {{ container.id }}, null, false);">
+                     onclick="context_menu(this, [{'contains': ['fortigate policy'], 'value': '{{ d.name|escapejs }}' }], 0, {{ container.id }}, null, false);">
                     {{ d.name }}
                     <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                   </a>

--- a/manual_readme_content.md
+++ b/manual_readme_content.md
@@ -7,8 +7,9 @@ application. Below are the explanation and usage of all those parameters.
 - **Username -** The username used for authentication.
 - **Password -** The password used for authentication.
 - **API Key -** The API Key used for authentication.
-- **Verify server certificate -** Enable or disable verify SSL certificates for HTTPS requests.
-  The default value is false.
+- **Verify server certificate -** Enable or disable verification of TLS certificates for HTTPS
+  requests. Verification is enabled by default; disable it only after explicitly accepting the
+  man-in-the-middle risk.
 - **Virtual domain (VDOM) -** It specifies the virtual domain to be used. It is an optional
   parameter. If no virtual domain is provided, it will use the one provided in the action
   parameters. And, if the virtual domain is not provided in the asset or action parameters, it

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,6 +1,6 @@
 **Unreleased**
 
-* - Escape dynamic policy names before embedding them in widget JavaScript.
-* - Enable TLS certificate verification by default.
-* - Treat FortiOS error bodies as failures and verify block and unblock mutations by reading policy state back.
-* - Reject containment operations against disabled deny policies.
+* Escape dynamic policy names before embedding them in widget JavaScript.
+* Enable TLS certificate verification by default.
+* Treat FortiOS error bodies as failures and verify block and unblock mutations by reading policy state back.
+* Reject containment operations against disabled deny policies.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,4 @@
 
 - Escape dynamic policy names before embedding them in widget JavaScript.
 - Enable TLS certificate verification by default.
+- Treat FortiOS error bodies as failures and verify block and unblock mutations by reading policy state back.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,6 +1,6 @@
 **Unreleased**
 
-- Escape dynamic policy names before embedding them in widget JavaScript.
-- Enable TLS certificate verification by default.
-- Treat FortiOS error bodies as failures and verify block and unblock mutations by reading policy state back.
-- Reject containment operations against disabled deny policies.
+* - Escape dynamic policy names before embedding them in widget JavaScript.
+* - Enable TLS certificate verification by default.
+* - Treat FortiOS error bodies as failures and verify block and unblock mutations by reading policy state back.
+* - Reject containment operations against disabled deny policies.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 - Escape dynamic policy names before embedding them in widget JavaScript.
+- Enable TLS certificate verification by default.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -3,3 +3,4 @@
 - Escape dynamic policy names before embedding them in widget JavaScript.
 - Enable TLS certificate verification by default.
 - Treat FortiOS error bodies as failures and verify block and unblock mutations by reading policy state back.
+- Reject containment operations against disabled deny policies.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+- Escape dynamic policy names before embedding them in widget JavaScript.


### PR DESCRIPTION
## Summary\n\n- escape FortiGate policy names before embedding them in widget JavaScript\n- enable TLS certificate verification by default\n- treat FortiOS error bodies as failures and verify containment mutations with readback\n- reject containment actions against disabled deny policies\n- refresh the central connector quality-hook baseline\n\nTracks [PAPP-38183](https://splunk.atlassian.net/browse/PAPP-38183), PSAAS-30732, PSAAS-30746, PSAAS-32128, and PSAAS-32361.\n\n## Quality gate\n\n- local pre-commit: passed\n- hosted pre-commit and compile: pending\n\nThis PR was created entirely with Codex (AI) assistance.

## Tracking

- PAPP: PAPP-38183
- PSAAS: PSAAS-30732, PSAAS-30746, PSAAS-32128, PSAAS-32361
- Written by Codex.